### PR TITLE
Saga stoped unexpectedly

### DIFF
--- a/Aqovia.Utilities.SagaMachine/Aqovia.Utilities.SagaMachine.csproj
+++ b/Aqovia.Utilities.SagaMachine/Aqovia.Utilities.SagaMachine.csproj
@@ -73,6 +73,7 @@
     <Compile Include="SagaException.cs" />
     <Compile Include="SagaMachine.cs" />
     <Compile Include="SagaStateStaleException.cs" />
+    <Compile Include="SagaHasConcurrentLockException.cs" />
     <Compile Include="StatePersistance\HashedValue.cs" />
     <Compile Include="StatePersistance\IKeyValueStore.cs" />
     <Compile Include="StatePersistance\RedisKeyValueStore.cs" />

--- a/Aqovia.Utilities.SagaMachine/KeyValueSagaProcessState.cs
+++ b/Aqovia.Utilities.SagaMachine/KeyValueSagaProcessState.cs
@@ -125,19 +125,15 @@ namespace Aqovia.Utilities.SagaMachine
 
         public ISagaDefined Execute()
         {
-            if (_needToDeleteState)
+            LoadStateIfNecessary();
+
+            string uniqueLockToken;
+            var isLocked = _keyValueStore.TakeLockWithShortTimeSpan(_currentState.Value.SagaInstanceId.ToString(), out uniqueLockToken);
+            if (!isLocked)
             {
-                if (!_keyValueStore.Remove(_currentState.Value.SagaInstanceId.ToString(), _currentState.Hash))
-                {
-                    throw new SagaStateStaleException("State has since changed. Can't remove");
-                }                
-            }
-            else
-            {
-                SaveStateIfNecessary();
+                throw new SagaHasConcurrentLockException("A concurrent SagaMachine has already locked the saga");
             }
 
-            
             foreach (var logStateMessage in _logState.GetLogMessages())
             {
                 IEventLogger logger = _eventLoggerFactory.GetRequestEventLogger(_incomingMessage.GetType().Name + "SagaMessage");
@@ -159,11 +155,29 @@ namespace Aqovia.Utilities.SagaMachine
                 else
                 {
                     logger.LogError(logStateMessage.Message);
-                }       
+                }
             }
 
+            try
+            {
+                _messagePublisher(_messagesToPublish).Wait();
 
-            _messagePublisher(_messagesToPublish).Wait();
+                if (_needToDeleteState)
+                {
+                    if (!_keyValueStore.Remove(_currentState.Value.SagaInstanceId.ToString(), _currentState.Hash))
+                    {
+                        throw new SagaStateStaleException("State has since changed. Can't remove");
+                    }
+                }
+                else
+                {
+                    SaveStateIfNecessary();
+                }
+            }
+            finally
+            {
+                _keyValueStore.ReleaseLock(_currentState.Value.SagaInstanceId.ToString(), uniqueLockToken);
+            }
             
             return null;
         }

--- a/Aqovia.Utilities.SagaMachine/KeyValueSagaProcessState.cs
+++ b/Aqovia.Utilities.SagaMachine/KeyValueSagaProcessState.cs
@@ -128,7 +128,7 @@ namespace Aqovia.Utilities.SagaMachine
             LoadStateIfNecessary();
 
             string uniqueLockToken;
-            var isLocked = _keyValueStore.TakeLockWithShortTimeSpan(_currentState.Value.SagaInstanceId.ToString(), out uniqueLockToken);
+            var isLocked = _keyValueStore.TakeLockWithDefaultExpiryTime(_currentState.Value.SagaInstanceId.ToString(), out uniqueLockToken);
             if (!isLocked)
             {
                 throw new SagaHasConcurrentLockException("A concurrent SagaMachine has already locked the saga");

--- a/Aqovia.Utilities.SagaMachine/SagaHasConcurrentLockException.cs
+++ b/Aqovia.Utilities.SagaMachine/SagaHasConcurrentLockException.cs
@@ -1,0 +1,10 @@
+namespace Aqovia.Utilities.SagaMachine
+{
+    public class SagaHasConcurrentLockException : SagaException
+    {
+        public SagaHasConcurrentLockException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/Aqovia.Utilities.SagaMachine/SagaMachine.cs
+++ b/Aqovia.Utilities.SagaMachine/SagaMachine.cs
@@ -43,12 +43,19 @@ namespace Aqovia.Utilities.SagaMachine
                     _processRegistry[typeof(TMessage)](message);
                     return;
                 }
-                catch (SagaStateStaleException)
+                catch (SagaException ex)
                 {
-                    //Key value store we read was stale. Try again.
-                    retryFailLimit--;
-                    if (retryFailLimit < 1)
+                    if (ex is SagaStateStaleException || ex is SagaHasConcurrentLockException)
+                    {
+                        //Key value store we read was stale. Try again.
+                        retryFailLimit--;
+                        if (retryFailLimit < 1)
+                            throw;
+                    }
+                    else
+                    {
                         throw;
+                    }
                 }
             }            
         }

--- a/Aqovia.Utilities.SagaMachine/StatePersistance/IKeyValueStore.cs
+++ b/Aqovia.Utilities.SagaMachine/StatePersistance/IKeyValueStore.cs
@@ -8,7 +8,7 @@ namespace Aqovia.Utilities.SagaMachine.StatePersistance
         bool TrySetValue<T>(string key, T value, string oldHash);
         bool Remove(string key, string oldHash);
         void Remove(string key);
-        bool TakeLockWithShortTimeSpan(string key, out string lockToken);
+        bool TakeLockWithDefaultExpiryTime(string key, out string lockToken);
         bool TakeLock(string key, out string lockToken, double milliseconds);
         bool ReleaseLock(string key, string lockToken);
         TimeSpan Ping();

--- a/Aqovia.Utilities.SagaMachine/StatePersistance/IKeyValueStore.cs
+++ b/Aqovia.Utilities.SagaMachine/StatePersistance/IKeyValueStore.cs
@@ -8,6 +8,9 @@ namespace Aqovia.Utilities.SagaMachine.StatePersistance
         bool TrySetValue<T>(string key, T value, string oldHash);
         bool Remove(string key, string oldHash);
         void Remove(string key);
+        bool TakeLockWithShortTimeSpan(string key, out string lockToken);
+        bool TakeLock(string key, out string lockToken, double milliseconds);
+        bool ReleaseLock(string key, string lockToken);
         TimeSpan Ping();
     }
 }

--- a/Aqovia.Utilities.SagaMachine/StatePersistance/RedisKeyValueStore.cs
+++ b/Aqovia.Utilities.SagaMachine/StatePersistance/RedisKeyValueStore.cs
@@ -8,6 +8,8 @@ namespace Aqovia.Utilities.SagaMachine.StatePersistance
 {
     public class RedisKeyValueStore : IKeyValueStore, IDisposable
     {
+        private const double DefaultLockExpiryTime = 500;
+
 
         private readonly RedisCachingSectionHandler _redisConfiguration;
         private readonly ConnectionMultiplexer _redis;
@@ -114,15 +116,9 @@ namespace Aqovia.Utilities.SagaMachine.StatePersistance
         /// <param name="key"></param>
         /// <param name="lockToken"></param>
         /// <returns></returns>
-        public bool TakeLockWithShortTimeSpan(string key, out string lockToken)
+        public bool TakeLockWithDefaultExpiryTime(string key, out string lockToken)
         {
-            lockToken = Guid.NewGuid().ToString();
-
-            var db = GetDatabase();
-            var transac = db.CreateTransaction();
-            transac.AddCondition(Condition.KeyExists(key));
-
-            return transac.LockTakeAsync(key, lockToken, TimeSpan.FromMilliseconds(500)).Result;
+            return TakeLock(key, out lockToken, DefaultLockExpiryTime);
         }
 
         /// <summary>

--- a/Aqovia.Utilities.SagaMachine/StatePersistance/RedisKeyValueStore.cs
+++ b/Aqovia.Utilities.SagaMachine/StatePersistance/RedisKeyValueStore.cs
@@ -106,6 +106,54 @@ namespace Aqovia.Utilities.SagaMachine.StatePersistance
             db.KeyDelete(key);
         }
 
+
+        /// <summary>
+        /// Request lock against key value element
+        /// Lock lifespan 500 milliseconds
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="lockToken"></param>
+        /// <returns></returns>
+        public bool TakeLockWithShortTimeSpan(string key, out string lockToken)
+        {
+            lockToken = Guid.NewGuid().ToString();
+
+            var db = GetDatabase();
+            var transac = db.CreateTransaction();
+            transac.AddCondition(Condition.KeyExists(key));
+
+            return transac.LockTakeAsync(key, lockToken, TimeSpan.FromMilliseconds(500)).Result;
+        }
+
+        /// <summary>
+        /// Request lock against key value element
+        /// Lock has lifespan specified in milliseconds
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="lockToken"></param>
+        /// <param name="milliseconds"></param>
+        /// <returns></returns>
+        public bool TakeLock(string key, out string lockToken, double milliseconds)
+        {
+            lockToken = Guid.NewGuid().ToString();
+
+            var db = GetDatabase();
+            var transac = db.CreateTransaction();
+            transac.AddCondition(Condition.KeyExists(key));
+
+            return transac.LockTakeAsync(key, lockToken, TimeSpan.FromMilliseconds(milliseconds)).Result;
+        }
+
+        public bool ReleaseLock(string key, string lockToken)
+        {
+            var db = GetDatabase();
+
+            var transac = db.CreateTransaction();
+            transac.AddCondition(Condition.KeyExists(key));
+
+            return transac.LockReleaseAsync(key, lockToken).Result;
+        }
+
         public void Dispose()
         {
             _redis.Close();


### PR DESCRIPTION
Fix to prevent a saga to be stopped when it has not yet published it's messages if any.

In the event of a failure while a message is being published, the Saga is not anymore stopped and the exception thrown.
