### PR TITLE
Fixing stopping a saga (e.g. StopSagaIf) errors if in same fluent sta…

### DIFF
--- a/src/Aqovia.Utilities.SagaMachine/KeyValueSagaProcessState.cs
+++ b/src/Aqovia.Utilities.SagaMachine/KeyValueSagaProcessState.cs
@@ -13,6 +13,7 @@ namespace Aqovia.Utilities.SagaMachine
         private readonly Func<IEnumerable<ISagaMessageIdentifier>, Task> _messagePublisher;
         private HashedValue<TState> _currentState;
         private bool _needToSaveState;
+        private bool _isInitialState;
         private bool _needToDeleteState;
         private readonly List<ISagaMessageIdentifier> _messagesToPublish;
         private readonly SagaLogState _logState;
@@ -37,7 +38,8 @@ namespace Aqovia.Utilities.SagaMachine
             {
                 Value = stateInit,
                 Hash = string.Empty
-            };                                
+            };
+            _isInitialState = true;
             _needToSaveState = true;
             return this;
         }
@@ -169,9 +171,12 @@ namespace Aqovia.Utilities.SagaMachine
 
                 if (_needToDeleteState)
                 {
-                    if (!_keyValueStore.Remove(_currentState.Value.SagaInstanceId.ToString(), _currentState.Hash))
+                    if (_isInitialState == false)
                     {
-                        throw new SagaStateStaleException("State has since changed. Can't remove");
+                        if (!_keyValueStore.Remove(_currentState.Value.SagaInstanceId.ToString(), _currentState.Hash))
+                        {
+                            throw new SagaStateStaleException("State has since changed. Can't remove");
+                        }
                     }
                 }
                 else

--- a/tests/Aqovia.Utilities.SagaMachine.Tests/StateMachineTests.cs
+++ b/tests/Aqovia.Utilities.SagaMachine.Tests/StateMachineTests.cs
@@ -374,8 +374,8 @@ namespace Aqovia.Utilities.SagaMachine.Tests
             _keyValueStoreMock.Verify(o => o.Remove(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
 
-        [Fact(DisplayName = "Should not delete state (as it won't exist) at the end of the saga if stop saga is with initialisestate")]
-        public async Task SagaMachineShouldNotDeleteStateAtEndOfSagaIfStopSagaIsWithInitialiseState()
+        [Fact(DisplayName = "Saga state is not saved when Saga is both Initialised and Stopped")]
+        public async Task SagaMachineStateIsNotSavedWhenSagaIsBothInitialisedAndStopped()
         {
             //Arrange
             _keyValueStoreMock.Setup(o => o.TakeLockWithDefaultExpiryTime(It.IsAny<string>(), It.IsAny<Guid>())).ReturnsAsync(true);


### PR DESCRIPTION
Fixing stopping a saga (e.g. StopSagaIf) errors if in same fluent statement as initialising the state (e.g. InitialiseState).